### PR TITLE
Adds POST /api/v1/export endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,81 @@
 
 All endpoints use [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme) to authenticate.
 
+## Export 
+
+```
+POST /api/v1/export
+```
+
+This endpoint accepts a TextIt flow event, fetches the contact information of the sender, and returns the data as plain text, to use for sending internal emails from TextIt.
+
+<details>
+<summary>Example request</summary>
+
+```
+curl --location --request POST 'http://localhost:8080/api/v1/export' \
+--header 'Accept: application/json' \
+--header 'Authorization: Basic [Your base64 encoded username and password]' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+   "contact": {
+      "name": "Aaron Schachter",
+      "urn": "tel:+12065551212",
+      "uuid": "a41aeb32-793c-46ba-b3ac-0bf9ada9f9bd"
+   },
+   "flow": {
+      "name": "Survey: Small Biz Alerts",
+      "uuid": "13a3aab9-063c-4388-8bb2-761c1ed6901a"
+   },
+   "results": {
+      "small_biz_alerts_anything_else": {
+         "category": "Has Text",
+         "value": "No"
+      },
+      "small_biz_survey_how_can_we_make_it_better": {
+         "category": "Has Text",
+         "value": "Change one thing"
+      },
+      "small_biz_survey_how_helpful": {
+         "category": "Other",
+         "value": "Haha"
+      },
+      "small_biz_survey_how_much_do_you_trust": {
+         "category": "Other",
+         "value": "Mostl "
+      },
+      "small_biz_survey_learned_something_new": {
+         "category": "Other",
+         "value": "Learned "
+      },
+      "small_biz_survey_what_do_you_like_most": {
+         "category": "Has Text",
+         "value": "Like most"
+      }
+   }
+}
+```
+
+</details>
+
+<details>
+<summary>Example response</summary>
+
+```
+{
+    "text": "name: \"Aaron Schachter\"\n\nphone: \"12065551212\"\n\nurl: \"https://textit.in/contact/read/a41aeb32-793c-46ba-b3ac-0bf9ada9f9bd\"\n\ncreated_on: \"2020-07-17T21:00:27.625572Z\"\n\ngroups: \"All Subscribers, Business Owner, Not Helping Employer, AK CARES question, Remove from Stats, Batch 2, Started Survey, Finished Survey\"\n\nflow: Survey: Small Biz Alerts\n\nsmall_biz_alerts_anything_else: {\"category\":\"Has Text\",\"value\":\"No\"}\n\nsmall_biz_survey_how_can_we_make_it_better: {\"category\":\"Has Text\",\"value\":\"Change one thing\"}\n\nsmall_biz_survey_how_helpful: {\"category\":\"Other\",\"value\":\"Haha\"}\n\nsmall_biz_survey_how_much_do_you_trust: {\"category\":\"Other\",\"value\":\"Mostl \"}\n\nsmall_biz_survey_learned_something_new: {\"category\":\"Other\",\"value\":\"Learned \"}\n\nsmall_biz_survey_what_do_you_like_most: {\"category\":\"Has Text\",\"value\":\"Like most\"}\n\nbusiness_name: Schachter daycare\n\nbusiness_owner_response: Yes\n\ndate_subscribed: 2020-08-04\n\ndate_unsubscribed: 2020-08-05\n\nhelping_employer_response: null\n\nnumber_of_employees: None\n\nreceived_stimulus: null\n\nresponse: null\n\ntest_campaign_date: null"
+}
+```
+
+</details>
+
 ## Zapier
 
 ```
 POST /api/v1/zapier/:id1/:id2
 ```
 
-This endpoint accepts a TextIt flow event, and fetches the contact information of the sender, and forwards the event and contact data to a [Zapier webhook](https://zapier.com/help/doc/how-get-started-webhooks-zapier). The :id1 and :id2 route parameters correspond to the two unique ID's within your Zapier webhook URL:
+This endpoint accepts a TextIt flow event, fetches the contact information of the sender, and forwards the event and contact data to a [Zapier webhook](https://zapier.com/help/doc/how-get-started-webhooks-zapier). The :id1 and :id2 route parameters correspond to the two unique ID's within your Zapier webhook URL:
 
 ```
 https://hooks.zapier.com/hooks/catch/:id1/:id2

--- a/lib/middleware/export/formatData.js
+++ b/lib/middleware/export/formatData.js
@@ -2,6 +2,11 @@
 
 const logger = require('heroku-logger');
 
+/**
+ * @param {String} fieldName
+ * @param {String} fieldValue
+ * @return {String}
+ */
 const formatPlainTextField = (fieldName, fieldValue) => {
   return `${fieldName}: ${fieldValue}`;
 }
@@ -15,6 +20,7 @@ module.exports = function formatData() {
         'name',
         'phone',
         'url',
+        'created_on',
         'groups'
       ];
 
@@ -23,16 +29,16 @@ module.exports = function formatData() {
         JSON.stringify(req.data[fieldName]),
       )));
 
-      plainTextResult.push('flow', req.data.flow.name);
+      plainTextResult.push(formatPlainTextField('flow', req.data.flow.name));
 
-      Object.keys(req.data.results).forEach(fieldName => plainTextResult.push(formatPlainTextField(
+      Object.keys(req.data.results).sort().forEach(fieldName => plainTextResult.push(formatPlainTextField(
         fieldName,
         JSON.stringify(req.data.results[fieldName]),
       )));
 
-      Object.keys(req.data.fields).forEach((fieldName) => {
+      req.data.fields ? Object.keys(req.data.fields).sort().forEach((fieldName) => {
         plainTextResult.push(formatPlainTextField(fieldName, req.data.fields[fieldName]));
-      });
+      }) : null;
 
       req.data = { text: plainTextResult.join('\n\n') }
 

--- a/lib/middleware/export/formatData.js
+++ b/lib/middleware/export/formatData.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+const formatPlainTextField = (fieldName, fieldValue) => {
+  return `${fieldName}: ${fieldValue}`;
+}
+
+module.exports = function formatData() {
+  return async (req, res, next) => {
+    try {
+      const plainTextResult = [];
+
+      const contactFields = [
+        'name',
+        'phone',
+        'url',
+        'groups'
+      ];
+
+      contactFields.forEach(fieldName => plainTextResult.push(formatPlainTextField(
+        fieldName,
+        JSON.stringify(req.data[fieldName]),
+      )));
+
+      plainTextResult.push('flow', req.data.flow.name);
+
+      Object.keys(req.data.results).forEach(fieldName => plainTextResult.push(formatPlainTextField(
+        fieldName,
+        JSON.stringify(req.data.results[fieldName]),
+      )));
+
+      Object.keys(req.data.fields).forEach((fieldName) => {
+        plainTextResult.push(formatPlainTextField(fieldName, req.data.fields[fieldName]));
+      });
+
+      req.data = { text: plainTextResult.join('\n\n') }
+
+      return next();
+    } catch (error) {
+      return next(error);
+    }
+  }
+};

--- a/routes.js
+++ b/routes.js
@@ -4,6 +4,7 @@ const logger = require('heroku-logger');
 
 const authenticateMiddleware = require('./lib/middleware/authenticate');
 const sendResponseMiddleware = require('./lib/middleware/sendResponse');
+const formatDataMiddleware = require('./lib/middleware/export/formatData');
 const parseFlowEventMiddleware = require('./lib/middleware/parseFlowEvent');
 const postZapierWebhookMiddleware = require('./lib/middleware/zapier/postZapierWebhook');
 
@@ -14,6 +15,11 @@ module.exports = (app) => {
   app.use(authenticateMiddleware());
 
   app.get('/', (req, res) => res.send('OK'));
+
+  app.post('/api/v1/export',
+    parseFlowEventMiddleware(),
+    formatDataMiddleware(),
+    sendResponseMiddleware());
 
   app.post('/api/v1/zapier/:id1/:id2',
     parseFlowEventMiddleware(),


### PR DESCRIPTION
This API route returns the same data that a `POST /zapier` response returns, except as a plain text string. We'll call this webhook from within TextIt to format a plain text string to use in a "Send Email" flow action:

<img width="400" alt="Screen Shot 2020-08-17 at 8 42 12 PM" src="https://user-images.githubusercontent.com/1236811/90467913-2a8b2880-e0ca-11ea-9bc0-86fc977775a3.png">
