### PR TITLE
Cleanup Zapier payload

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,13 +51,15 @@ curl --location --request POST 'http://localhost:8080/api/v1/flow-events?zapier=
         "Phone": "tel:+12065551212",
         "Profile": "https://textit.in/contact/read/a41aeb32-793c-46ba-b3ac-0bf9ada9f9bd",
         "Created On": "2020-07-17T21:00:27.625572Z",
-        "Groups": "All Subscribers, Business Owner, Not Helping Employer, AK CARES question, Remove from Stats, Batch 2, Started Survey, Finished Survey",
+        "Groups": "All Subscribers, Business Owner, Not Helping Employer, Healthcare provider, Public Facing / Food Business, AK CARES question, Remove from Stats, Batch 2, Started Survey, Finished Survey",
         "Business Name": "Schachter daycare",
         "Helping Employer Response": null,
         "Number Of Employees": "None",
+        "Flow": "Admin: Aaron Test",
+        "Submitted": "2020-08-26T03:51:57.849Z",
         "Ready": "Hello there"
     },
-    "text": "Name:\nAaron Schachter\n\n\nPhone:\ntel:+12065551212\n\n\nProfile:\nhttps://textit.in/contact/read/a41aeb32-793c-46ba-b3ac-0bf9ada9f9bd\n\n\nCreated On:\n2020-07-17T21:00:27.625572Z\n\n\nGroups:\nAll Subscribers, Business Owner, Not Helping Employer, AK CARES question, Remove from Stats, Batch 2, Started Survey, Finished Survey\n\n\nBusiness Name:\nSchachter daycare\n\n\nHelping Employer Response:\nnull\n\n\nNumber Of Employees:\nNone\n\nFlow Name: undefined\n\nReady:\nHello there\n\n",
+    "text": "Name:\nAaron Schachter\n\nPhone:\ntel:+12065551212\n\nProfile:\nhttps://textit.in/contact/read/a41aeb32-793c-46ba-b3ac-0bf9ada9f9bd\n\nCreated On:\n2020-07-17T21:00:27.625572Z\n\nGroups:\nAll Subscribers, Business Owner, Not Helping Employer, Healthcare provider, Public Facing / Food Business, AK CARES question, Remove from Stats, Batch 2, Started Survey, Finished Survey\n\nBusiness Name:\nSchachter daycare\n\nHelping Employer Response:\nnull\n\nNumber Of Employees:\nNone\n\nFlow:\nAdmin: Aaron Test\n\nSubmitted:\n2020-08-26T03:51:57.849Z\n\nReady:\nHello there\n",
     "responses": {
         "zapier": {
             "id": "414a1bc4-722d-4f3a-8787-47229e213d21",

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assign, omit, pick, startCase } = require('lodash');
+const { assign, cloneDeep, omit, pick, startCase } = require('lodash');
 
 const { getUrlForContactId } = require('./services/text-it');
 
@@ -80,9 +80,5 @@ const getPlainTextFromObject = (data) => Object.keys(data)
  * @param {Object}
  * @return {String}
  */
-module.exports.getPlainTextFromReq = (req) => {
-  const contact = getPlainTextFromObject(omit(req.contact, 'Uuid'));
-  const results = getPlainTextFromObject(req.results);
-
-  return `${contact}Flow Name:\n${req.flow.Name}\n${results}`;
-};
+module.exports.getPlainTextFromReq = req => 
+  getPlainTextFromObject(cloneDeep(omit(req.data, 'Uuid')));

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -84,5 +84,5 @@ module.exports.getPlainTextFromReq = (req) => {
   const contact = getPlainTextFromObject(omit(req.contact, 'Uuid'));
   const results = getPlainTextFromObject(req.results);
 
-  return `${contact}Flow Name: ${req.flow.name}\n\n${results}`;
+  return `${contact}Flow Name:\n\n${req.flow.Name}\n\n${results}`;
 };

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -66,7 +66,7 @@ module.exports.formatTextItResults = (results) => {
  * @param {String} fieldValue
  * @return {String}
  */
-const getPlainTextLine = (fieldName, fieldValue) => `${fieldName}:\n${fieldValue}\n\n`;
+const getPlainTextLine = (fieldName, fieldValue) => `${fieldName}:\n${fieldValue}\n`;
 
 /**
  * @param {Object} data
@@ -84,5 +84,5 @@ module.exports.getPlainTextFromReq = (req) => {
   const contact = getPlainTextFromObject(omit(req.contact, 'Uuid'));
   const results = getPlainTextFromObject(req.results);
 
-  return `${contact}Flow Name:\n\n${req.flow.Name}\n\n${results}`;
+  return `${contact}Flow Name:\n${req.flow.Name}\n${results}`;
 };

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -28,7 +28,7 @@ module.exports = function parseFlowEvent() {
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);
       req.data.Flow = req.flow.Name;
-      req.data.Submitted = Date.now();
+      req.data.Submitted = new Date().toISOString();
 
       assign(req.data, req.results);
    

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -27,7 +27,9 @@ module.exports = function parseFlowEvent() {
 
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);
-      req.Flow = req.flow.name;
+      req.data.Flow = req.flow.name;
+      req.data.Submitted = Date.now();
+
       assign(req.data, req.results);
    
       // Initialize to save responses when forwarding flow event to third-party services.

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -27,7 +27,7 @@ module.exports = function parseFlowEvent() {
 
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);
-      req.data.Flow = req.flow.name;
+      req.data.Flow = req.flow.Name;
       req.data.Submitted = Date.now();
 
       assign(req.data, req.results);

--- a/lib/middleware/sendResponse.js
+++ b/lib/middleware/sendResponse.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { assign } = require('lodash');
 const logger = require('heroku-logger');
 
 const { getPlainTextFromReq } = require('../formatters');


### PR DESCRIPTION
Adds missing `Flow` and `Submitted` properties for sending to Zapier. Simplifies constructing the plain text response by just using the same Zapier `req.data` payload.