### PR TITLE
Display flow results in order they are collected

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ AIRTABLE_BASE_ID=
 
 TEXT_IT_API_TOKEN=
 TEXT_IT_ALL_SUBSCRIBERS_GROUP_ID=
+
+# Set this field to a comma separated list of snake_case fields names if only want a subset
+# e.g. business_name,number_of_employees
+TEXT_IT_CONTACT_FIELDS= 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assign, cloneDeep, omit, pick, snakeCase, startCase } = require('lodash');
+const { assign, cloneDeep, omit, pick, startCase } = require('lodash');
 
 const { getUrlForContactId } = require('./services/text-it');
 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -44,17 +44,26 @@ module.exports.formatTextItContact = (contact) => {
 };
 
 /**
+ * Formats the results from the flow in the same sequence the fields are collected in flow.
+ *
  * @param {Object} results
+ * @param {Array} flowFields
  * @return {Object}
  */
-module.exports.formatTextItResults = (results) => {
+module.exports.formatTextItResults = (results, flowFields) => {
   const formatted = {};
 
-  Object.keys(results).forEach((fieldName) => {
-    const { category, value } = results[fieldName];
+  flowFields.forEach((fieldConfig) => {
+    const result = results[fieldConfig.key];
+
+    if (!result) {
+      return;
+    }
+
+    const { category, value } = result;
     const openTextCategories = ['All Responses', 'Has Text'];
 
-    formatted[startCase(fieldName)] = openTextCategories.includes(category) ? value : category;
+    formatted[fieldConfig.name] = openTextCategories.includes(category) ? value : category;
   });
 
   return formatted;

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -19,16 +19,6 @@ module.exports.startCaseObjectKeys = (data) => {
 };
 
 /**
- * @param {String} tableName
- * @return {Array}
- */
-const getFieldList = (tableName) => {
-  const config = process.env[`${snakeCase(tableName).toUpperCase()}_FIELDS`];
-
-  return config ? config.split(',') : [];
-}
-
-/**
  * @param {Object} contact
  * @return {Object}
  */
@@ -37,7 +27,8 @@ module.exports.formatTextItContact = (contact) => {
   // Assumes we're only supporting SMS.
   const phone = urns.length ? contact.urns[0] : contact.urn;
 
-  const fieldList = getFieldList('Contacts');
+  const fieldConfig = process.env.TEXT_IT_CONTACT_FIELDS;
+  const fieldList = fieldConfig ? fieldConfig.split(',') : [];
   const fieldsToAdd = fieldList.length ? pick(fields, fieldList) : fields; 
 
   return module.exports.startCaseObjectKeys(

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assign, cloneDeep, omit, pick, startCase } = require('lodash');
+const { assign, cloneDeep, omit, pick, snakeCase, startCase } = require('lodash');
 
 const { getUrlForContactId } = require('./services/text-it');
 
@@ -19,6 +19,16 @@ module.exports.startCaseObjectKeys = (data) => {
 };
 
 /**
+ * @param {String} tableName
+ * @return {Array}
+ */
+const getFieldList = (tableName) => {
+  const config = process.env[`${snakeCase(tableName).toUpperCase()}_FIELDS`];
+
+  return config ? config.split(',') : [];
+}
+
+/**
  * @param {Object} contact
  * @return {Object}
  */
@@ -26,6 +36,9 @@ module.exports.formatTextItContact = (contact) => {
   const { created_on, fields = {}, groups = [], name, uuid, urns = [] } = contact;
   // Assumes we're only supporting SMS.
   const phone = urns.length ? contact.urns[0] : contact.urn;
+
+  const fieldList = getFieldList('Contacts');
+  const fieldsToAdd = fieldList.length ? pick(fields, fieldList) : fields; 
 
   return module.exports.startCaseObjectKeys(
     assign({
@@ -35,12 +48,7 @@ module.exports.formatTextItContact = (contact) => {
       profile: getUrlForContactId(uuid),
       created_on,
       groups: groups ? groups.map(group => group.name).join(', ') : null,
-    // TODO: This should be set via config variable.
-    }, pick(fields, [
-      'business_name',
-      'helping_employer_response',
-      'number_of_employees',
-    ]))
+    }, fieldsToAdd)
   );
 };
 

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -16,14 +16,18 @@ module.exports = function parseFlowEvent() {
       const { contact, flow, results } = body;
       const { uuid } = contact;
 
-      req.flow = formatters.startCaseObjectKeys(flow);
-      req.results = formatters.formatTextItResults(results);
-
       const getContactRes = await textIt.getContactById(uuid);
 
-      logger.debug('TextIt response', getContactRes);
+      logger.debug('TextIt getContactRes', getContactRes);
 
       req.contact = formatters.formatTextItContact(getContactRes ? getContactRes : contact);
+      req.flow = formatters.startCaseObjectKeys(flow);
+
+      const getFlowRes = await textIt.getFlowById(flow.uuid);
+
+      logger.debug('TextIt getFlowRes', getContactRes);
+
+      req.results = formatters.formatTextItResults(results, getFlowRes.results);
 
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -19,11 +19,11 @@ module.exports = function parseFlowEvent() {
       req.flow = formatters.startCaseObjectKeys(flow);
       req.results = formatters.formatTextItResults(results);
 
-      const textItRes = await textIt.getContactById(uuid);
+      const getContactRes = await textIt.getContactById(uuid);
 
-      logger.debug('TextIt response', textItRes);
+      logger.debug('TextIt response', getContactRes);
 
-      req.contact = formatters.formatTextItContact(textItRes ? textItRes : contact);
+      req.contact = formatters.formatTextItContact(getContactRes ? getContactRes : contact);
 
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);

--- a/lib/services/text-it.js
+++ b/lib/services/text-it.js
@@ -81,6 +81,17 @@ module.exports.getContactById = (contactId) => {
 };
 
 /**
+ * Fetch flow by ID.
+ *
+ * @param {String}
+ * @return {Promise}
+ */
+module.exports.getFlowById = (flowId) => {
+  return get('flows', { uuid: flowId })
+    .then(res => res.body.results[0]);
+};
+
+/**
  * Fetch first page of groups.
  *
  * @param {String}


### PR DESCRIPTION
This PR modifies the `text` response used for sending emails to list the flow result fields in the order they are collected when the flow is run. To do this, we add an extra query to `GET /flows?uuid=` for the flow, which lists all fields collected by sequence in the `results` array.

It also fixes the TODO of setting the fields to pick from a Contact as a config variable, instead of hardcoding specifically for Small Biz Alerts.