### PR TITLE
Upsert Airtable records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,9 @@ curl --location --request POST 'http://localhost:8080/api/v1/flow-events?zapier=
         "category": "Has Text",
         "value": "Hello there"
       }
+   },
+   "run": {
+      "uuid": "a977ec65-9efa-4f15-8c3d-c3e65edc029d"
    }
 }
 ```
@@ -95,6 +98,7 @@ curl --location --request POST 'http://localhost:8080/api/v1/flow-events?zapier=
         "Business Name": "Schachter daycare",
         "Helping Employer Response": null,
         "Number Of Employees": "None",
+        "Run": "a977ec65-9efa-4f15-8c3d-c3e65edc029d",
         "Flow": "Admin: Aaron Test",
         "Submitted": "2020-08-26T03:51:57.849Z",
         "Ready": "Hello there"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ All endpoints use [basic authentication](https://developer.mozilla.org/en-US/doc
 POST /api/v1/run-results
 ```
 
-This endpoint accepts a request from a TextIt "Call Webhook" action in TextIt. It parses the flow run results, returns them as plain text, and can forward the data to Zapier or Airtable if query parameters are passed.
+This endpoint accepts a request from a "Call Webhook" action in a TextIt flow. It parses the flow run results, returns them as plain text, and forwards the data to a Zapier webhook or Airtable base if query parameters are passed.
 
 #### Configuration
 
@@ -154,7 +154,7 @@ To save run results into the table passed via `airtable` query parameter:
     * `Run` (Single-line text)
     * The run result fields, in Title Case -- e.g. `How Helpful Rating`
 
-* Create a TextIt flow with various "Wait for response" actions, saving each result to the corresponding Airtable field name, -- e.g. `How Helpful Rating`.
+* Create a TextIt flow with various "Wait For Response" actions, saving each result to the corresponding Airtable field name -- e.g. `How Helpful Rating`.
 
 * Each time you want to upsert the user's responses within the flow, add a "Call Webhook" action to post to the `run-results?airtable=TableName` endpoint with the name of the table to upsert to, using PascalCase for the table name.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,36 @@ POST /api/v1/flow-events
 
 This endpoint accepts a TextIt flow event, fetches the contact information of the sender, and returns the data as plain text, to use for sending internal emails from TextIt.
 
+Use the "Call Webhook" action in TextIt to post to this endpoint.
+
+Add this payload to the default POST body to include the TextIt Run ID, used to upsert records per a flow run:
+
+```
+  "run", object(
+    "uuid", run.uuid, 
+    "flow", run.flow.uuid
+  ),
+```
+
+So the complete POST body looks like:
+
+```
+@(json(object(
+  "contact", object(
+    "uuid", contact.uuid, 
+    "name", contact.name, 
+    "urn", contact.urn
+  ),
+  "flow", object(
+    "uuid", run.flow.uuid, 
+    "name", run.flow.name
+  ),
+  "run", object(
+    "uuid", run.uuid
+  ),
+  "results", foreach_value(results, extract_object, "value", "category")
+)))
+```
 
 <details>
 <summary>Example request</summary>

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ It also forwards the flow event data if certain query parameters are passed.
 POST /api/v1/run-results?airtable=SurveyResults
 ```
 
-If an `airtable` query parameter is passed, the run results will be used to upsert a record in the table passed as the query parameter (in this example, a table called "Survey Results").
+If an `airtable` query parameter is passed, the run results will be used to upsert a record in the table passed as the query parameter (in this example, a table called `Survey Results`).
 
 It requires that there are `Contacts` and `Flows` tables set up:
 
@@ -137,7 +137,8 @@ It requires that there are `Contacts` and `Flows` tables set up:
    * `Profile` (Phone number)
    * `Created On` (Date)
    * `Groups` (Long text)
-   * (Additional contact fields, in Title Case)
+   * Additional contact fields, in Title Case -- e.g. `Business Name`.
+       * If you do not wish to store all fields on a TextIt contact in the corresponding Airtable, set a `TEXT_IT_CONTACT_FIELDS` config variable to specify which contact fields should be maintained in Airtable -- e.g.`TEXT_IT_CONTACT_FIELDS=business_name,helping_employer_response,number_of_employees`
 
 * `Flows`
    * `Uuid` (Single-line text)
@@ -145,15 +146,17 @@ It requires that there are `Contacts` and `Flows` tables set up:
 
 The table to upsert a record into requires `Contact` and `Flow` link fields, as well as a `Run` text field to use for upserting results of a flow run.
 
-To create a new table:
+To save run results into the table passed via `airtable` query parameter:
 
-* First create the table in Airtable, with fields:
+* First, create the table in Airtable with fields:
     * `Contact` (Link to Contacts)
     * `Flow` (Link to Flows)
     * `Run` (Single-line text)
-    * (Run result fields, in Title Case)
+    * The run result fields, in Title Case -- e.g. `How Helpful Rating`
 
-* Next, create the flow in TextIt, using the new table field names for the various results to save during a flow run.
+* Create a TextIt flow with various "Wait for response" actions, saving each result to the corresponding Airtable field name, -- e.g. `How Helpful Rating`.
+
+* Each time you want to upsert the user's responses within the flow, add a "Call Webhook" action to post to the `run-results?airtable=TableName` endpoint with the name of the table to upsert to, using PascalCase for the table name.
 
 Always add a new field to Airtable first before saving it as a new result in TextIt -- Airtable will return a 422 if you attempt to write to a field that doesn't exist on a table.
 

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 const superagent = require('superagent');
-const { assign, isEqual, omit, startCase } = require('lodash');
+const { assign, omit, startCase } = require('lodash');
 
 const airtable = require('../services/airtable');
 
@@ -15,33 +15,47 @@ const apiResponseFieldName = 'API Response';
  * @return {Boolean}
  */
 const upsert = async (tableName, primaryFieldName, fields) => {
+  const primaryFieldValue = fields[primaryFieldName];
+
   let record = await airtable
-    .getRecordByFieldName(tableName, primaryFieldName, fields[primaryFieldName]);
+    .getRecordByFieldName(tableName, primaryFieldName, primaryFieldValue);
 
-  if (record) {
-    logger.debug('Found Airtable record', { tableName, primaryFieldName, record });
+  if (!record) {
+    record = await airtable.createRecord(tableName, fields);
 
-    const hasUpdated = Object.keys(omit(fields, apiResponseFieldName)).some((fieldName) => {
-      return fields[fieldName] !== record.fields[fieldName];
-    })
+    logger.debug('Created Airtable record', { tableName, primaryFieldName, record });
 
-    if (!hasUpdated) {
-      return record;
-    }
-
-    const { id } = record;
-
-    return await airtable.patchRecord(
-      tableName,
-      assign({ id }, { fields: omit(fields, [primaryFieldName, 'Flow', 'Contact', apiResponseFieldName]) }),
-    );
+    return record;
   }
 
-  record = await airtable.createRecord(tableName, fields);
+  logger.debug('Found Airtable record', { tableName, primaryFieldName, record });
 
-  logger.debug('Created Airtable record', { tableName, primaryFieldName, record });
+  const updates = {};
 
-  return record;
+  Object.keys(omit(fields, ['Flow', 'Contact', apiResponseFieldName])).forEach((fieldName) => {
+    const fieldValue = fields[fieldName];
+
+    if (fieldValue !== record.fields[fieldName]) {
+      updates[fieldName] = fieldValue;
+    }
+  });
+
+  if (!Object.keys(updates).length) {
+    logger.debug('No updates for Airtable record', {
+      tableName,
+      primaryFieldName,
+      primaryFieldValue,
+    });
+
+    return record;
+  }
+
+  const { id } = record;
+
+  return await airtable.patchRecord(
+    tableName,
+    assign({ id }, { fields: updates }),
+  );
 };
 
 module.exports = function createRecord() {

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -12,7 +12,8 @@ const airtable = require('../services/airtable');
  * @return {Boolean}
  */
 const findOrCreateAirtableRecord = async (tableName, primaryFieldName, fields) => {
-  let record = await airtable.getRecordByUuid(tableName, fields[primaryFieldName]);
+  let record = await airtable
+    .getRecordByFieldName(tableName, primaryFieldName, fields[primaryFieldName]);
 
   if (record) {
     logger.debug('Found Airtable record', { tableName, primaryFieldName, record });

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -11,7 +11,7 @@ const airtable = require('../services/airtable');
  * @param {Object} fields
  * @return {Boolean}
  */
-const findOrCreateAirtableRecord = async (tableName, primaryFieldName, fields) => {
+const upsert = async (tableName, primaryFieldName, fields) => {
   let record = await airtable
     .getRecordByFieldName(tableName, primaryFieldName, fields[primaryFieldName]);
 
@@ -47,8 +47,8 @@ module.exports = function createRecord() {
         return next();
       }
 
-      const contactRecord = await findOrCreateAirtableRecord('Contacts', 'Uuid', req.contact);
-      const flowRecord = await findOrCreateAirtableRecord('Flows', 'Uuid', req.flow);
+      const contactRecord = await upsert('Contacts', 'Uuid', req.contact);
+      const flowRecord = await upsert('Flows', 'Uuid', req.flow);
 
       const payload = assign({
         'Contact': contactRecord.id,
@@ -59,7 +59,7 @@ module.exports = function createRecord() {
         payload.Run = req.runId;
       }
 
-      const flowEventRecord = await findOrCreateAirtableRecord(flowEventTableName, 'Run', payload);
+      const flowEventRecord = await upsert(flowEventTableName, 'Run', payload);
 
       logger.debug('createRecord response', flowEventRecord);
 

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -11,18 +11,18 @@ const airtable = require('../services/airtable');
  * @param {Object} fields
  * @return {Boolean}
  */
-const findOrCreateAirtableRecord = async (tableName, fields) => {
-  let record = await airtable.getRecordByUuid(tableName, fields.Uuid);
+const findOrCreateAirtableRecord = async (tableName, primaryFieldName, fields) => {
+  let record = await airtable.getRecordByUuid(tableName, fields[primaryFieldName]);
 
   if (record) {
-    logger.debug('Found Airtable record', { tableName, record });
+    logger.debug('Found Airtable record', { tableName, primaryFieldName, record });
 
     return record;
   }
 
   record = await airtable.createRecord(tableName, fields);
 
-  logger.debug('Created Airtable record', { tableName, record });
+  logger.debug('Created Airtable record', { tableName, primaryFieldName, record });
 
   return record;
 };
@@ -37,8 +37,8 @@ module.exports = function createRecord() {
         return next();
       }
 
-      const contactRecord = await findOrCreateAirtableRecord('Contacts', req.contact);
-      const flowRecord = await findOrCreateAirtableRecord('Flows', req.flow);
+      const contactRecord = await findOrCreateAirtableRecord('Contacts', 'Uuid', req.contact);
+      const flowRecord = await findOrCreateAirtableRecord('Flows', 'Uuid', req.flow);
 
       const payload = assign({
         'Contact': contactRecord.id,

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -6,6 +6,9 @@ const { assign, isEqual, omit, startCase } = require('lodash');
 
 const airtable = require('../services/airtable');
 
+// This is the field name that should be used to store the result of posts to our API.
+const apiResponseFieldName = 'API Response';
+
 /**
  * @param {String} tableName
  * @param {Object} fields
@@ -18,7 +21,11 @@ const upsert = async (tableName, primaryFieldName, fields) => {
   if (record) {
     logger.debug('Found Airtable record', { tableName, primaryFieldName, record });
 
-    if (isEqual(record.fields, fields)) {
+    const hasUpdated = Object.keys(omit(fields, apiResponseFieldName)).some((fieldName) => {
+      return fields[fieldName] !== record.fields[fieldName];
+    })
+
+    if (!hasUpdated) {
       return record;
     }
 
@@ -26,7 +33,7 @@ const upsert = async (tableName, primaryFieldName, fields) => {
 
     return await airtable.patchRecord(
       tableName,
-      assign({ id }, { fields: omit(fields, [primaryFieldName, 'Flow', 'Contact', 'Ignore']) }),
+      assign({ id }, { fields: omit(fields, [primaryFieldName, 'Flow', 'Contact', apiResponseFieldName]) }),
     );
   }
 
@@ -36,7 +43,6 @@ const upsert = async (tableName, primaryFieldName, fields) => {
 
   return record;
 };
-
 
 module.exports = function createRecord() {
   return async (req, res, next) => {

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 const superagent = require('superagent');
-const { assign, startCase } = require('lodash');
+const { assign, isEqual, omit, startCase } = require('lodash');
 
 const airtable = require('../services/airtable');
 
@@ -18,7 +18,16 @@ const findOrCreateAirtableRecord = async (tableName, primaryFieldName, fields) =
   if (record) {
     logger.debug('Found Airtable record', { tableName, primaryFieldName, record });
 
-    return record;
+    if (isEqual(record.fields, fields)) {
+      return record;
+    }
+
+    const { id } = record;
+
+    return await airtable.patchRecord(
+      tableName,
+      assign({ id }, { fields: omit(fields, [primaryFieldName, 'Flow', 'Contact', 'Ignore']) }),
+    );
   }
 
   record = await airtable.createRecord(tableName, fields);
@@ -50,7 +59,7 @@ module.exports = function createRecord() {
         payload.Run = req.runId;
       }
 
-      const flowEventRecord = await airtable.createRecord(flowEventTableName, payload);
+      const flowEventRecord = await findOrCreateAirtableRecord(flowEventTableName, 'Run', payload);
 
       logger.debug('createRecord response', flowEventRecord);
 

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -45,6 +45,10 @@ module.exports = function createRecord() {
         'Flow': flowRecord.id,
       }, req.results);
 
+      if (req.runId) {
+        payload.Run = req.runId;
+      }
+
       const flowEventRecord = await airtable.createRecord(flowEventTableName, payload);
 
       logger.debug('createRecord response', flowEventRecord);

--- a/lib/middleware/airtable.js
+++ b/lib/middleware/airtable.js
@@ -75,8 +75,8 @@ module.exports = function createRecord() {
         'Flow': flowRecord.id,
       }, req.results);
 
-      if (req.runId) {
-        payload.Run = req.runId;
+      if (req.data.Run) {
+        payload.Run = req.data.Run;
       }
 
       const flowEventRecord = await upsert(flowEventTableName, 'Run', payload);

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -31,6 +31,11 @@ module.exports = function parseFlowEvent() {
 
       // Save the payload to send to Zapier and as the response to this API request.
       req.data = cloneDeep(req.contact);
+
+      if (body.run) {
+        req.runId = body.run.uuid;
+      }
+
       req.data.Flow = req.flow.Name;
       req.data.Submitted = new Date().toISOString();
 

--- a/lib/middleware/parseFlowEvent.js
+++ b/lib/middleware/parseFlowEvent.js
@@ -33,7 +33,7 @@ module.exports = function parseFlowEvent() {
       req.data = cloneDeep(req.contact);
 
       if (body.run) {
-        req.runId = body.run.uuid;
+        req.data.Run = body.run.uuid;
       }
 
       req.data.Flow = req.flow.Name;

--- a/lib/services/airtable.js
+++ b/lib/services/airtable.js
@@ -52,12 +52,13 @@ module.exports.createRecord = (tableName, fields) => post(tableName, {
 }).then(res => res.body.records[0]);
 
 /**
- * Gets a record in Airtable for given tableName and given Uuid field value.
+ * Gets a record in Airtable for given table name and field name / value.
  *
  * @param {String} tableName
- * @param {String} uuid
+ * @param {String} fieldName
+ * @param {String} fieldValue
  * @return {Promise}
  */
-module.exports.getRecordByUuid = (tableName, uuid) => get(tableName, {
-  filterByFormula: `Uuid="${uuid}"`,
+module.exports.getRecordByFieldName = (tableName, fieldName, fieldValue) => get(tableName, {
+  filterByFormula: `${fieldName}="${fieldValue}"`,
 }).then(res => res.body.records[0]);

--- a/lib/services/airtable.js
+++ b/lib/services/airtable.js
@@ -24,6 +24,22 @@ function get(path, query) {
 }
 
 /**
+ * Execute a PATCH request to the Airtable baseId.
+ *
+ * @param {String} path
+ * @param {Object} data
+ * @return {Promise}
+ */
+function patch(path, data) {
+  logger.info('Airtable PATCH', { path, data });
+
+  return client
+    .patch(`${baseUri}${encodeURI(path)}`)
+    .set('Authorization', `Bearer ${apiKey}`)
+    .send(data);
+}
+
+/**
  * Execute a POST request to the Airtable baseId.
  *
  * @param {String} path
@@ -48,6 +64,18 @@ function post(path, data) {
  */
 module.exports.createRecord = (tableName, fields) => post(tableName, {
   records: [{ fields }],
+  typecast: true,
+}).then(res => res.body.records[0]);
+
+/**
+ * Patches a record in Airtable for given tableName and given record.
+ *
+ * @param {String} tableName
+ * @param {Object} record
+ * @return {Promise}
+ */
+module.exports.patchRecord = (tableName, record) => patch(tableName, {
+  records: [record],
   typecast: true,
 }).then(res => res.body.records[0]);
 

--- a/routes.js
+++ b/routes.js
@@ -16,7 +16,14 @@ module.exports = (app) => {
 
   app.get('/', (req, res) => res.send('OK'));
 
+  // To be deprecated by run-results
   app.post('/api/v1/flow-events',
+    parseFlowEventMiddleware(),
+    zapierMiddleware(),
+    airtableMiddleware(),
+    sendResponseMiddleware());
+
+  app.post('/api/v1/run-results',
     parseFlowEventMiddleware(),
     zapierMiddleware(),
     airtableMiddleware(),


### PR DESCRIPTION
This PR renames the `flow-events` endpoint to `run-results`, and upserts an Airtable record if a TextIt flow run uuid is passed and the target table contains a `Run` text field.